### PR TITLE
Support "symbolic" configs.

### DIFF
--- a/tests/test_twitter_bot.py
+++ b/tests/test_twitter_bot.py
@@ -18,6 +18,17 @@ class MockSettings(Settings):
         self.MESSAGE_PROVIDER = 'twitter_bot.messages.HelloWorldMessageProvider'
         self.SINCE_ID_PROVIDER = 'twitter_bot.since_id.FileSystemProvider'
 
+class MockSymbolicSettings(Settings):
+    """ Test settings """
+    def __init__(self):
+        super(MockSettings, self).__init__()
+        self.OAUTH_TOKEN = 'change_me'
+        self.OAUTH_SECRET = 'change_me'
+        self.CONSUMER_KEY = 'change_me'
+        self.CONSUMER_SECRET = 'change_me'
+        self.MESSAGE_PROVIDER = twitter_bot.messages.HelloWorldMessageProvider
+        self.SINCE_ID_PROVIDER = twitter_bot.since_id.FileSystemProvider
+
 
 class MockTwitterHTTPError(TwitterHTTPError):
     def __init__(self, e):
@@ -58,6 +69,14 @@ class TestTwitterBot(unittest.TestCase):
                              "settings, this value is loaded from the TWITTER_MESSAGE_PROVIDER "
                              "environment variable. If TWITTER_MESSAGE_PROVIDER is not set, "
                              "'messages.HelloWorldMessageProvider' will be used.", '{0}'.format(e))
+
+    def test_constructor_symbolic_config(self):
+        settings = MockSymbolicSettings()
+        
+        bot = TwitterBot(settings=settings)
+        # assertIsInstance came in in python 2.7; this lib supports 2.6.
+        self.assertTrue(isinstance(twitter_bot.messages.HelloWorldMessageProvider, bot.messages))
+        self.assertTrue(isinstance(twitter_bot.since_id.FileSystemProvider, bot.since_id))
 
     def test_get_error_no_hashtags(self):
         error = self.bot._get_error('An error has occurred', [])

--- a/twitter_bot/twitter_bot.py
+++ b/twitter_bot/twitter_bot.py
@@ -12,12 +12,15 @@ logging.basicConfig(filename='logs/twitter_bot.log',
                     level=logging.DEBUG)
 
 
-def get_class(module_name):
-    module_parts = module_name.split('.')
-    module = __import__('.'.join(module_parts[:-1]), fromlist=(module_parts[-1],))
-    class_ = getattr(module, module_parts[-1])
-    return class_()
+def get_class(class_or_name):
+    if isinstance(class_or_name, str):
+        class_or_name = _get_class_by_name(class_or_name)
+    return _class_or_name()
 
+def _get_class_by_name(class_name):
+    module_name, symbol_name = class_name.rsplit('.', 1)
+    module = __import__(module_name)
+    return getattr(module, symbol_name)
 
 class TwitterBot(object):
     """ Bot for interacting with Twitter


### PR DESCRIPTION
A config entry is symbolic if it binds directly to a Python symbol, rather than
binding to a string containing the name of a Python symbol. This means that
apps using symbolic bindings find out early, as soon as the config _class_ is
defined, whether they've misspelled a class or module name.

I've also simplified the string-to-symbol resolution a bit.