### PR TITLE
Add MarkhovChainMessageProvider

### DIFF
--- a/tests/test_markov_chain.py
+++ b/tests/test_markov_chain.py
@@ -1,0 +1,26 @@
+import unittest
+
+from twitter_bot import messages
+
+MARKOV_TEXT = "a b c d"
+
+class TestMarkovChain(unittest.TestCase):
+
+    def test_instantiate(self):
+        chain = messages.MarkovChainMessageProvider(MARKOV_TEXT)
+
+    def test_a_random_word(self):
+        chain = messages.MarkovChainMessageProvider(MARKOV_TEXT)
+        word = chain.a_random_word()
+        self.assertTrue(word in ["a", "b", "c", "d"])
+
+    def test_a_random_word_with_args(self):
+        chain = messages.MarkovChainMessageProvider(MARKOV_TEXT)
+        word = chain.a_random_word("a")
+        self.assertEqual("b", word)
+
+    def test_create_message(self):
+        chain = messages.MarkovChainMessageProvider(MARKOV_TEXT)
+        message = chain.create(None)
+        self.assertTrue(message)
+        self.assertTrue(len(message) < 140)

--- a/twitter_bot/messages.py
+++ b/twitter_bot/messages.py
@@ -1,3 +1,7 @@
+import os
+import random
+from . import settings
+
 class HelloWorldMessageProvider(object):
 
     def create(self, mention):
@@ -9,4 +13,42 @@ class HelloWorldMessageProvider(object):
         return "Hello World!"
 
 
-__all__ = ["HelloWorldMessageProvider"]
+class MarkovChainMessageProvider(object):
+
+    def __init__(self, text=None):
+        text_path = os.environ.get('TWITTER_MARKOV_TEXT_PATH')
+        if not (text or text_path):
+            raise settings.SettingsError("Must specify Markov text path. This "
+                "is loaded from the TWITTER_MARKOV_TEXT_PATH environment "
+                "variable.")
+
+        text = text or open(text_path, 'r').read()
+        markov_dict = {}
+        words = text.split()
+        prev_word = words[0]
+        for word in words[1:]:
+            if not markov_dict.get(prev_word):
+                markov_dict[prev_word] = []
+            markov_dict[prev_word].append(word)
+            prev_word = word
+
+        self.markov_dict = markov_dict
+
+    def a_random_word(self, prev_word=None):
+        if prev_word and self.markov_dict.get(prev_word):
+            return random.choice(self.markov_dict[prev_word])
+        else:
+            return random.choice(list(self.markov_dict.keys()))
+
+    def create(self, mention):
+        message = []
+
+        def message_len():
+            return sum([len(w) + 1 for w in message])
+
+        while message_len() < 140:
+            message.append(self.a_random_word(message[-1] if message else None))
+
+        return ' '.join(message[:-1])
+
+__all__ = ["HelloWorldMessageProvider", "MarkovChainMessageProvider"]


### PR DESCRIPTION
This message provider reads a text file, breaks it up into words, and generates nonsense text based on the original text.

It currently ignores mention data, but future work could select a word from the mention and use that as a seed into the `markhov_dict`.

Not sure if you want this in the twitterbot library itself, but I think it's reasonable because "ebooks" bots seem to be quite popular.